### PR TITLE
Pivot output table to have format that resembles the AMP table better

### DIFF
--- a/moz_forecasting/ad_tiles_forecast/config.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config.yaml
@@ -137,6 +137,6 @@ output:
     database: jsnyder
     table: amp_rpm_forecasts
   prod:
-    project: mozdata
-    database: revenue_cat3_analysis
-    table: amp_rpm_forecasts
+    project: moz-fx-data-shared-prod
+    database: ads_derived
+    table: tiles_monthly_v1

--- a/moz_forecasting/ad_tiles_forecast/config_2025_planning_baseline.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config_2025_planning_baseline.yaml
@@ -207,6 +207,6 @@ output:
     database: jsnyder
     table: tiles_monthly
   prod:
-    project: mozdata
-    database: revenue_cat3_analysis
-    table: tiles_monthly
+    project: moz-fx-data-shared-prod
+    database: ads_derived
+    table: tiles_monthly_v1

--- a/moz_forecasting/ad_tiles_forecast/config_2025_planning_baseline.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config_2025_planning_baseline.yaml
@@ -3,7 +3,7 @@ observed_months: 12
 observed_months_fill_rate: 4
 
 # Revenue per Mille, agreed contractually with Admarketplace.
-RPM:
+CPM:
   AU: 
     tiles_1_and_2: 0.099
     tile3: .077
@@ -199,5 +199,14 @@ new_markets:
       - GB
       - IT
 
-# no output info because we don't want to write
-
+# specify the output database and table
+# to write the data to
+output:
+  test:
+    project: moz-fx-data-bq-data-science
+    database: jsnyder
+    table: tiles_monthly
+  prod:
+    project: mozdata
+    database: revenue_cat3_analysis
+    table: tiles_monthly

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -877,6 +877,7 @@ class AdTilesForecastFlow(FlowSpec):
             bigquery.SchemaField("device", "STRING"),
             bigquery.SchemaField("forecast_month", "DATETIME"),
             bigquery.SchemaField("forecast_predicted_at", "TIMESTAMP"),
+            bigquery.SchemaField("position", "STRING"),
             bigquery.SchemaField("impressions", "FLOAT"),
             bigquery.SchemaField("revenue", "FLOAT"),
             bigquery.SchemaField("CPM", "FLOAT"),

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -740,6 +740,19 @@ class AdTilesForecastFlow(FlowSpec):
             ]
         )
 
+        by_country_cpm_list = []
+        for country, cpms in CPMs.items():
+            by_country_cpm_list.append(
+                {"country": country, "position": "1", "CPM": cpms["tiles_1_and_2"]}
+            )
+            by_country_cpm_list.append(
+                {"country": country, "position": "2", "CPM": cpms["tiles_1_and_2"]}
+            )
+            by_country_cpm_list.append(
+                {"country": country, "position": "3", "CPM": cpms["tile3"]}
+            )
+        self.by_country_cpm_df = pd.DataFrame(by_country_cpm_list)
+
         revenue_forecast = pd.merge(self.revenue_forecast, CPM_df, on="country")
 
         # Desktop CPMs were increased by 10% in summer of 2024
@@ -791,37 +804,58 @@ class AdTilesForecastFlow(FlowSpec):
     @step
     def end(self):
         """Write to BQ."""
-        write_df = self.output_df
+        id_vars = ["country", "submission_month", "forecast_type"]
+        revenue_df = self.output_df[
+            [
+                "country",
+                "submission_month",
+                "forecast_type",
+                "revenue_tile1",
+                "revenue_tile2",
+                "revenue_tile3",
+            ]
+        ].melt(
+            id_vars=id_vars,
+            value_vars=["revenue_tile1", "revenue_tile2", "revenue_tile3"],
+            var_name="position",
+            value_name="revenue",
+        )
 
+        revenue_df["position"] = revenue_df["position"].str.slice(start=-1)
+
+        impressions_df = self.output_df[
+            [
+                "country",
+                "submission_month",
+                "forecast_type",
+                "expected_impressions_tile1",
+                "expected_impressions_tile2",
+                "expected_impressions_tile3",
+            ]
+        ].melt(
+            id_vars=id_vars,
+            value_vars=[
+                "expected_impressions_tile1",
+                "expected_impressions_tile2",
+                "expected_impressions_tile3",
+            ],
+            var_name="position",
+            value_name="impressions",
+        )
+
+        impressions_df["position"] = impressions_df["position"].str.slice(start=-1)
+
+        write_df = impressions_df.merge(
+            revenue_df, on=id_vars + ["position"], how="inner"
+        )
         write_df["device"] = "desktop"
         write_df["forecast_month"] = self.first_day_of_current_month
         write_df = write_df.merge(self.forecast_predicted_at, how="inner", on="device")
+        write_df = write_df.merge(
+            self.by_country_cpm_df, on=["country", "position"], how="inner"
+        )
 
-        write_df = write_df[
-            [
-                "forecast_month",
-                "forecast_predicted_at",
-                "country",
-                "submission_month",
-                "inventory_forecast",
-                "expected_impressions",
-                "revenue",
-                "device",
-                "forecast_type",
-            ]
-        ]
-
-        assert set(write_df.columns) == {
-            "forecast_month",
-            "forecast_predicted_at",
-            "country",
-            "submission_month",
-            "inventory_forecast",
-            "expected_impressions",
-            "revenue",
-            "device",
-            "forecast_type",
-        }
+        self.write_df = write_df
         if not self.write or "output" not in self.config_data:
             return
 
@@ -837,15 +871,15 @@ class AdTilesForecastFlow(FlowSpec):
             f"{output_info['project']}.{output_info['database']}.{output_info['table']}"
         )
         schema = [
-            bigquery.SchemaField("forecast_month", "DATETIME"),
-            bigquery.SchemaField("forecast_predicted_at", "TIMESTAMP"),
             bigquery.SchemaField("country", "STRING"),
             bigquery.SchemaField("submission_month", "DATETIME"),
-            bigquery.SchemaField("inventory_forecast", "FLOAT"),
-            bigquery.SchemaField("expected_impressions", "FLOAT"),
-            bigquery.SchemaField("revenue", "FLOAT"),
-            bigquery.SchemaField("device", "STRING"),
             bigquery.SchemaField("forecast_type", "STRING"),
+            bigquery.SchemaField("device", "STRING"),
+            bigquery.SchemaField("forecast_month", "DATETIME"),
+            bigquery.SchemaField("forecast_predicted_at", "TIMESTAMP"),
+            bigquery.SchemaField("impressions", "FLOAT"),
+            bigquery.SchemaField("revenue", "FLOAT"),
+            bigquery.SchemaField("CPM", "FLOAT"),
         ]
         job_config = bigquery.LoadJobConfig(
             write_disposition="WRITE_APPEND", schema=schema

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -97,7 +97,7 @@ class AdTilesForecastFlow(FlowSpec):
         name="config",
         is_text=True,
         help="configuration for flow",
-        default="moz_forecasting/ad_tiles_forecast/config.yaml",
+        default="moz_forecasting/ad_tiles_forecast/config_2025_planning_baseline.yaml",
     )
 
     test_mode = Parameter(
@@ -862,10 +862,13 @@ class AdTilesForecastFlow(FlowSpec):
             bigquery.SchemaField("CPM", "FLOAT"),
         ]
         job_config = bigquery.LoadJobConfig(
-            write_disposition="WRITE_APPEND", schema=schema
+            write_disposition="WRITE_APPEND",
+            create_disposition="CREATE_NEVER",
+            schema=schema,
         )
 
         client = bigquery.Client(project=GCP_PROJECT_NAME)
+        print(f"writing to: {target_table}")
 
         client.load_table_from_dataframe(write_df, target_table, job_config=job_config)
 

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -772,8 +772,8 @@ class AdTilesForecastFlow(FlowSpec):
         direct_sales_df = revenue_forecast.copy()
         for impression_col in self.expected_impression_columns:
             for forecast_type, df in {
-                "with_direct_sales": no_direct_sales_df,
-                "no_direct_sales": direct_sales_df,
+                False: no_direct_sales_df,
+                True: direct_sales_df,
             }.items():
                 impressions_direct_sales_col = impression_col + "_direct_sales"
                 df[impressions_direct_sales_col] = (
@@ -787,7 +787,7 @@ class AdTilesForecastFlow(FlowSpec):
                 else:
                     # all others apply tiles 1 and 2 CPM
                     df[revenue_col] = df[impression_col] * df["CPM"] / 1000
-                df["forecast_type"] = forecast_type
+                df["direct_sales_included"] = forecast_type
 
         revenue_forecast = pd.concat([no_direct_sales_df, direct_sales_df])
 
@@ -804,12 +804,12 @@ class AdTilesForecastFlow(FlowSpec):
     @step
     def end(self):
         """Write to BQ."""
-        id_vars = ["country", "submission_month", "forecast_type"]
+        id_vars = ["country", "submission_month", "direct_sales_included"]
         revenue_df = self.output_df[
             [
                 "country",
                 "submission_month",
-                "forecast_type",
+                "direct_sales_included",
                 "revenue_tile1",
                 "revenue_tile2",
                 "revenue_tile3",
@@ -827,7 +827,7 @@ class AdTilesForecastFlow(FlowSpec):
             [
                 "country",
                 "submission_month",
-                "forecast_type",
+                "direct_sales_included",
                 "expected_impressions_tile1",
                 "expected_impressions_tile2",
                 "expected_impressions_tile3",
@@ -873,7 +873,7 @@ class AdTilesForecastFlow(FlowSpec):
         schema = [
             bigquery.SchemaField("country", "STRING"),
             bigquery.SchemaField("submission_month", "DATETIME"),
-            bigquery.SchemaField("forecast_type", "STRING"),
+            bigquery.SchemaField("direct_sales_included", "BOOLEAN"),
             bigquery.SchemaField("device", "STRING"),
             bigquery.SchemaField("forecast_month", "DATETIME"),
             bigquery.SchemaField("forecast_predicted_at", "TIMESTAMP"),


### PR DESCRIPTION
Update the output table so that it is now includes additional position index.  Now each row represents a specific tile position for a given country, date, and forecast.

CPM by country and position also joined on

New output table has the following schema:

```
            bigquery.SchemaField("country", "STRING"),
            bigquery.SchemaField("submission_month", "DATETIME"),
            bigquery.SchemaField("direct_sales_included", "BOOLEAN"),
            bigquery.SchemaField("device", "STRING"),
            bigquery.SchemaField("forecast_month", "DATETIME"),
            bigquery.SchemaField("forecast_predicted_at", "TIMESTAMP"),
            bigquery.SchemaField("position", "STRING"),
            bigquery.SchemaField("impressions", "FLOAT"),
            bigquery.SchemaField("revenue", "FLOAT"),
            bigquery.SchemaField("CPM", "FLOAT"),
```