### PR TITLE
Use config.yaml as monthly forecast

### DIFF
--- a/moz_forecasting/ad_tiles_forecast/config.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config.yaml
@@ -56,9 +56,6 @@ CPM:
   LU:
     tiles_1_and_2: 0.05
     tile3: 0
-  SE:
-    tiles_1_and_2: 0.05
-    tile3: 0
   CH: 
     tiles_1_and_2: 0.250
     tile3: 0 #switzerland
@@ -139,6 +136,13 @@ elgibility:
                 submission_date >= "2022-01-25"
                 AND version > 92
                 AND country = "JP"
+              )
+              OR
+              -- 2025 baseline expansion countries
+              (
+                submission_date >= "2021-09-07"
+                AND version > 92
+                AND country IN ("BE","AT","PL","NL","CH", "LU","SG")
               )
             ));
 

--- a/moz_forecasting/ad_tiles_forecast/config.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config.yaml
@@ -1,3 +1,4 @@
+# config for montly runs
 # number of months of historical data to average over to get factors
 observed_months: 12
 observed_months_fill_rate: 12
@@ -6,13 +7,13 @@ observed_months_fill_rate: 12
 CPM:
   AU: 
     tiles_1_and_2: 0.099
-    tile3: .077
+    tile3: 0
   BR: 
     tiles_1_and_2: 0.066
-    tile3: 0.019
+    tile3: 0
   CA: 
     tiles_1_and_2: 0.330
-    tile3: 0.299
+    tile3: 0
   DE: 
     tiles_1_and_2: 0.528
     tile3: 0.187
@@ -32,14 +33,35 @@ CPM:
     tiles_1_and_2: 0.363
     tile3: 0.132
   JP:
-    tiles_1_and_2: 0.022
-    tile3: 0.0072
+    tiles_1_and_2: 0.06
+    tile3: 0
   MX:
     tiles_1_and_2: 0.209
-    tile3: 0.0649
+    tile3: 0
   US: 
     tiles_1_and_2: 0.627
     tile3: 0.220
+  BE: 
+    tiles_1_and_2: 0.150
+    tile3: 0
+  AT:
+    tiles_1_and_2: 0.17
+    tile3: 0
+  PL:
+    tiles_1_and_2: 0.050
+    tile3: 0
+  NL:
+    tiles_1_and_2: 0.22
+    tile3: 0
+  LU:
+    tiles_1_and_2: 0.05
+    tile3: 0
+  SE:
+    tiles_1_and_2: 0.05
+    tile3: 0
+  CH: 
+    tiles_1_and_2: 0.250
+    tile3: 0 #switzerland
 
 # list of direct allocation time windows
 # each element in the list is a timeframe
@@ -58,7 +80,7 @@ direct_allocations:
       IT: 1.00
       ES: 1.00
     allocation: .05
-    start_month: 2025-02
+    start_month: 2025-01
     positions:
       - 3
 

--- a/moz_forecasting/ad_tiles_forecast/config.yaml
+++ b/moz_forecasting/ad_tiles_forecast/config.yaml
@@ -56,6 +56,9 @@ CPM:
   LU:
     tiles_1_and_2: 0.05
     tile3: 0
+  SG:
+    tiles_1_and_2: 0.05
+    tile3: 0
   CH: 
     tiles_1_and_2: 0.250
     tile3: 0 #switzerland

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -155,6 +155,7 @@ class AdTilesForecastFlow(FlowSpec):
 
         # for scheduled flows set test_mode with env var SCH_METAFLOW_PARAM_TEST_MODE
         # load config
+        logging.info(f"Using config file: {self.config}")
         self.config_data = yaml.safe_load(self.config)
         test_mode_envar = os.environ.get("SCH_METAFLOW_PARAM_TEST_MODE")
         if test_mode_envar is not None:

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -155,7 +155,7 @@ class AdTilesForecastFlow(FlowSpec):
 
         # for scheduled flows set test_mode with env var SCH_METAFLOW_PARAM_TEST_MODE
         # load config
-        logging.info(f"Using config file: {self.config}")
+        logging.info(f"Using config:\n{self.config}")
         self.config_data = yaml.safe_load(self.config)
         test_mode_envar = os.environ.get("SCH_METAFLOW_PARAM_TEST_MODE")
         if test_mode_envar is not None:

--- a/moz_forecasting/ad_tiles_forecast/flow.py
+++ b/moz_forecasting/ad_tiles_forecast/flow.py
@@ -117,7 +117,7 @@ class AdTilesForecastFlow(FlowSpec):
         name="config",
         is_text=True,
         help="configuration for flow",
-        default="moz_forecasting/ad_tiles_forecast/config_2025_planning_stretch.yaml",
+        default="moz_forecasting/ad_tiles_forecast/config.yaml",
     )
 
     test_mode_param = Parameter(


### PR DESCRIPTION
AK requested the monthly desktop tiles forecast do the following:

```
I think we would want to include both the latest set of countries as well as the most up to date rates to reflect rest of year outlook, so the 17 countries currently live at scale (excluding Sweden) at the latest CPMs
```

This PR implements this, adding some missing countries and updating rates for existing ones based on the sheet below:
https://docs.google.com/spreadsheets/d/1CVX9Zt-QJd9vyaATVpFq_Xrsyh_Z0sUWt_YVhz-AMXE